### PR TITLE
Setup local Kind cluster with Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# kubernetes

--- a/kind/README.md
+++ b/kind/README.md
@@ -1,0 +1,120 @@
+# 🚀 Hello App on Kubernetes with Kind and Ingress
+
+This project sets up a local Kubernetes environment using Kind (Kubernetes in Docker) and deploys a simple HTTP echo application.
+
+It demonstrates how to:
+
+1. Create a local Kubernetes cluster using Kind with ports **80 and 443 mapped to localhost** — allowing access via browser or `curl`.
+2. Deploy a lightweight HTTP echo service using the [`hashicorp/http-echo`](https://hub.docker.com/r/hashicorp/http-echo) container.
+3. Expose the service internally via a standard Kubernetes `Service`.
+4. Expose the service externally using an `Ingress` with the **NGINX Ingress Controller**, making it accessible at:
+
+   ```
+   http://localhost/hello
+   ```
+
+5. Enable easy local testing of Ingress routes without needing cloud services, TLS certificates, or DNS — ideal for:
+   - Local development and debugging
+   - Learning Kubernetes Ingress concepts
+   - Demonstrating microservice exposure through Ingress
+
+---
+
+## 📦 What’s Included
+
+| File               | Description                                      |
+|--------------------|--------------------------------------------------|
+| `kind-config.yaml` | Custom Kind config with port mappings (80/443)  |
+| `hello-app.yaml`   | Deployment + Service for the echo container      |
+| `hello-ingress.yaml` | Ingress resource for the `/hello` path         |
+
+---
+
+## ✅ Prerequisites
+
+Make sure the following tools are installed:
+
+- [Docker](https://www.docker.com/)
+- [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+
+---
+
+## 🛠 Setup Instructions
+
+### 1. Create the Kind Cluster
+
+```bash
+kind create cluster --config kind-config.yaml
+```
+
+> This maps port 80 and 443 from your host to the Kind node.
+
+---
+
+### 2. Deploy NGINX Ingress Controller
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.10.0/deploy/static/provider/kind/deploy.yaml
+kubectl label node kind-control-plane ingress-ready=true
+```
+
+---
+
+### 3. Deploy the Application
+
+```bash
+kubectl apply -f hello-app.yaml
+```
+
+---
+
+### 4. Deploy the Ingress Resource
+
+```bash
+kubectl apply -f hello-ingress.yaml
+```
+
+---
+
+## 🌐 Test the Setup
+
+Once everything is deployed, test the endpoint:
+
+```bash
+curl http://localhost/hello
+```
+
+You should see:
+
+```
+Hello from Kind!
+```
+
+---
+
+## 🧪 Troubleshooting
+
+- Check if the ingress controller is running:
+  ```bash
+  kubectl get pods -n ingress-nginx
+  ```
+
+- Describe the ingress resource:
+  ```bash
+  kubectl describe ingress hello-ingress
+  ```
+
+- View services:
+  ```bash
+  kubectl get svc
+  ```
+
+---
+
+## 🧭 What This Project Does (Summary)
+
+- Creates a local Kind cluster with port mappings
+- Deploys a simple HTTP echo container
+- Exposes the app using Kubernetes `Ingress` + NGINX
+- Provides a clean way to test microservice routing locally

--- a/kind/hello-deployment.yml
+++ b/kind/hello-deployment.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-app
+  template:
+    metadata:
+      labels:
+        app: hello-app
+    spec:
+      containers:
+        - name: hello-container
+          image: hashicorp/http-echo
+          args:
+            - "-text=Hello from Kind!"
+          ports:
+            - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+spec:
+  selector:
+    app: hello-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5678

--- a/kind/hello-ingress.yml
+++ b/kind/hello-ingress.yml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /hello
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-service
+                port:
+                  number: 80

--- a/kind/kind-config.yaml
+++ b/kind/kind-config.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
This pull request introduces a new project that sets up a local Kubernetes environment using Kind (Kubernetes in Docker) to deploy a simple HTTP echo application. The changes include configuration files for the cluster, deployment, service, and ingress, along with extensive documentation in the `README.md` files. Below is a summary of the most important changes:

### Documentation Updates
* Added a detailed guide in `kind/README.md` that explains how to set up a local Kubernetes cluster with Kind, deploy an HTTP echo application, and expose it using an NGINX ingress. The guide includes prerequisites, setup instructions, testing steps, and troubleshooting tips.

### Kubernetes Configuration
* Introduced `kind/kind-config.yaml` to define a Kind cluster configuration with port mappings for HTTP (80) and HTTPS (443) to enable local access.
* Added `kind/hello-deployment.yml` to define a Kubernetes deployment for the HTTP echo application and a corresponding service to expose it internally.
* Added `kind/hello-ingress.yml` to define an ingress resource that exposes the application externally at `/hello` using the NGINX ingress controller.

### Cleanup
* Removed the outdated `# kubernetes` header from the root `README.md`.